### PR TITLE
chore: add meta Llama 4 notice attribution

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,1 @@
+Llama 4 is licensed under the Llama 4 Community License, Copyright © Meta Platforms, Inc. All Rights Reserved.

--- a/README.adoc
+++ b/README.adoc
@@ -75,3 +75,13 @@ This property specifies the classification labels that will be applied to evalua
 Supported labels are typically documented in the model’s card or configuration file.
 
 NOTE: Labels must be provided as a comma-separated list.
+
+== Notice
+
+This policy may use models based on meta LLama 4:
+- [gravitee-io/Llama-Prompt-Guard-2-22M](https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-22M)
+- [gravitee-io/Llama-Prompt-Guard-2-86M](https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-86M)
+
+``
+Llama 4 is licensed under the Llama 4 Community License, Copyright © Meta Platforms, Inc. All Rights Reserved.
+``

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,35 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license-maven-plugin.version}</version>
+                <configuration>
+                    <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                    <properties>
+                        <owner>The Gravitee team</owner>
+                        <email>http://gravitee.io</email>
+                    </properties>
+                    <excludes>
+                        <exclude>LICENSE.txt</exclude>
+                        <exclude>**/README</exclude>
+                        <exclude>src/main/packaging/**</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                        <exclude>src/main/resources/**</exclude>
+                        <exclude>src/main/webapp/**</exclude>
+                        <exclude>node_modules/**</exclude>
+                        <exclude>dist/**</exclude>
+                        <exclude>.tmp/**</exclude>
+                        <exclude>.*</exclude>
+                        <exclude>.*/**</exclude>
+                        <exclude>**/*.adoc</exclude>
+                        <exclude>**/*.adoc</exclude>
+                        <exclude>NOTICE.txt</exclude>
+                    </excludes>
+                    <skip>${skip.validation}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>${maven-plugin-assembly.version}</version>


### PR DESCRIPTION
**Description**

This PR adds meta Llama 4 attribution for the models that the plugin may rely on

