### PR TITLE
fix: README dead links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -80,7 +80,7 @@ NOTE: Labels must be provided as a comma-separated list.
 
 This plugin exposes models based on meta LLama4:
 
-* link:https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-22M[gravitee-io/Llama-Prompt-Guard-2-22M]
-* link:https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-86M[gravitee-io/Llama-Prompt-Guard-2-86M]
+* link:https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-22M-onnx[gravitee-io/Llama-Prompt-Guard-2-22M-onxx]
+* link:https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-86M-onnx[gravitee-io/Llama-Prompt-Guard-2-86M-onxx]
 
 ``Llama 4 is licensed under the Llama 4 Community License, Copyright © Meta Platforms, Inc. All Rights Reserved.``


### PR DESCRIPTION
**Description**

This PR fixes dead links in the README
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-fix-dead-link-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ai-prompt-guard-rails/1.0.0-fix-dead-link-SNAPSHOT/gravitee-policy-ai-prompt-guard-rails-1.0.0-fix-dead-link-SNAPSHOT.zip)
  <!-- Version placeholder end -->
