### PR TITLE
chore: include notice in binaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,13 @@
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>NOTICE.txt</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
         </resources>
         <plugins>
             <plugin>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -49,6 +49,14 @@
         <fileSet>
             <directory>${basedir}</directory>
             <includes>
+                <include>NOTICE.txt</include>
+            </includes>
+            <outputDirectory></outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}</directory>
+            <includes>
                 <include>${icon}</include>
             </includes>
         </fileSet>


### PR DESCRIPTION
**Description**

This PR ensure distribution of NOTICE.txt in jar and zip
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-chore-notice-in-binaries-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ai-prompt-guard-rails/1.0.0-chore-notice-in-binaries-SNAPSHOT/gravitee-policy-ai-prompt-guard-rails-1.0.0-chore-notice-in-binaries-SNAPSHOT.zip)
  <!-- Version placeholder end -->
