### PR TITLE
fix: bump ai-resource dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,11 @@
     <properties>
         <!-- Gravitee dependencies version -->
         <gravitee-apim.version>4.8.1</gravitee-apim.version>
-        <gravitee-resource-ai-model-api.version>1.0.0</gravitee-resource-ai-model-api.version>
+        <gravitee-inference-service.version>1.2.0</gravitee-inference-service.version>
+        <gravitee-resource-ai-model-api.version>2.1.0</gravitee-resource-ai-model-api.version>
+
+        <!-- Tests -->
+        <gravitee-resource-ai-model-text-classification.version>2.0.0-bump-ai-model-resource-api-SNAPSHOT</gravitee-resource-ai-model-text-classification.version>
 
         <!-- Maven plugins -->
         <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>
@@ -104,6 +108,18 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.resource</groupId>
+            <artifactId>gravitee-resource-ai-model-text-classification</artifactId>
+            <version>${gravitee-resource-ai-model-text-classification.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.inference.service</groupId>
+            <artifactId>gravitee-inference-service</artifactId>
+            <version>${gravitee-inference-service.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <gravitee-resource-ai-model-api.version>2.1.0</gravitee-resource-ai-model-api.version>
 
         <!-- Tests -->
-        <gravitee-resource-ai-model-text-classification.version>2.0.0-bump-ai-model-resource-api-SNAPSHOT</gravitee-resource-ai-model-text-classification.version>
+        <gravitee-resource-ai-model-text-classification.version>2.0.0</gravitee-resource-ai-model-text-classification.version>
 
         <!-- Maven plugins -->
         <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-ai-prompt-guard-rails</artifactId>
     <version>1.0.0</version>
+
+    <name>Gravitee.io APIM - Policy - AI - Prompt Guard Rails</name>
     <description>Uses AI text classification model to detect inappropriate, harmful, or adversarial user inputs, including profanity, explicit content, and attempts to bypass safety measures</description>
 
     <parent>

--- a/src/main/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicy.java
+++ b/src/main/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicy.java
@@ -22,9 +22,8 @@ import io.gravitee.policy.ai.prompt.guard.rails.configuration.AiPromptGuardRails
 import io.gravitee.policy.ai.prompt.guard.rails.configuration.RequestPolicy;
 import io.gravitee.policy.ai.prompt.guard.rails.model.AiModelResourceProvider;
 import io.gravitee.policy.api.annotations.RequireResource;
-import io.gravitee.reporter.api.v4.metric.Metrics;
-import io.gravitee.resource.ai_model.api.ClassifierResults;
 import io.gravitee.resource.ai_model.api.model.PromptInput;
+import io.gravitee.resource.ai_model.api.result.ClassifierResults;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableSource;
 import java.util.Set;

--- a/src/main/java/io/gravitee/policy/ai/prompt/guard/rails/model/AiModelResourceProvider.java
+++ b/src/main/java/io/gravitee/policy/ai/prompt/guard/rails/model/AiModelResourceProvider.java
@@ -17,7 +17,8 @@ package io.gravitee.policy.ai.prompt.guard.rails.model;
 
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.policy.ai.prompt.guard.rails.configuration.AiPromptGuardRailsConfiguration;
-import io.gravitee.resource.ai_model.api.AiTextClassificationModelResource;
+import io.gravitee.resource.ai_model.api.AiTextModelResource;
+import io.gravitee.resource.ai_model.api.result.ClassifierResults;
 import io.gravitee.resource.api.ResourceManager;
 
 public class AiModelResourceProvider {
@@ -28,7 +29,7 @@ public class AiModelResourceProvider {
         this.configuration = configuration;
     }
 
-    public AiTextClassificationModelResource<?> get(HttpPlainExecutionContext ctx) {
-        return ctx.getComponent(ResourceManager.class).getResource(configuration.resourceName(), AiTextClassificationModelResource.class);
+    public AiTextModelResource<?, ?, ClassifierResults> get(HttpPlainExecutionContext ctx) {
+        return ctx.getComponent(ResourceManager.class).getResource(configuration.resourceName(), AiTextModelResource.class);
     }
 }

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AbstractAiPromptGuardRailsPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AbstractAiPromptGuardRailsPolicyIntegrationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.ai.prompt.guard.rails;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.inference.service.InferenceService;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.resource.ResourcePlugin;
+import io.gravitee.policy.ai.prompt.guard.rails.configuration.AiPromptGuardRailsConfiguration;
+import io.gravitee.reporter.api.v4.metric.AdditionalMetric;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.gravitee.resource.ai_model.TextClassificationAiModelResource;
+import io.gravitee.resource.ai_model.configuration.TextClassificationAiModelConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.nio.file.Files;
+import java.util.Map;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@GatewayTest
+class AbstractAiPromptGuardRailsPolicyIntegrationTest
+    extends AbstractPolicyTest<AiPromptGuardRailsPolicy, AiPromptGuardRailsConfiguration> {
+
+    private static final Integer DELAY_BEFORE_REQUEST = 5;
+    BehaviorSubject<Metrics> metricsSubject;
+
+    private static InferenceService inferenceService;
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    @SneakyThrows
+    public void configureResources(Map<String, ResourcePlugin> resources) {
+        inferenceService = new InferenceService(getBean(Vertx.class), Files.createTempDirectory("models").toString());
+        inferenceService.start();
+    }
+
+    @AfterAll
+    @SneakyThrows
+    static void afterAll() {
+        inferenceService.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        metricsSubject = BehaviorSubject.create();
+
+        FakeReporter fakeReporter = getBean(FakeReporter.class);
+        fakeReporter.setReportableHandler(reportable -> {
+            if (reportable instanceof Metrics) {
+                metricsSubject.onNext((Metrics) reportable);
+                metricsSubject.onComplete();
+            }
+        });
+    }
+}

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsIntegrationTest.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 
 import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
@@ -28,6 +29,7 @@ import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
 import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
 import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.inference.service.InferenceService;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
@@ -36,25 +38,36 @@ import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.policy.ai.prompt.guard.rails.configuration.AiPromptGuardRailsConfiguration;
 import io.gravitee.reporter.api.v4.metric.AdditionalMetric;
 import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.gravitee.resource.ai_model.TextClassificationAiModelResource;
+import io.gravitee.resource.ai_model.client.TextClassificationInferenceClient;
+import io.gravitee.resource.ai_model.configuration.ModelConfiguration;
+import io.gravitee.resource.ai_model.configuration.ModelEnum;
+import io.gravitee.resource.ai_model.configuration.TextClassificationAiModelConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
+import java.nio.file.Files;
 import java.util.Map;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @Slf4j
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @GatewayTest(v2ExecutionMode = ExecutionMode.V4_EMULATION_ENGINE)
 class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuardRailsPolicy, AiPromptGuardRailsConfiguration> {
 
+    private static final Integer DELAY_BEFORE_REQUEST = 5;
     BehaviorSubject<Metrics> metricsSubject;
+
+    private static InferenceService inferenceService;
 
     @Override
     public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
@@ -66,6 +79,28 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
         endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
     }
 
+    @Override
+    @SneakyThrows
+    public void configureResources(Map<String, ResourcePlugin> resources) {
+        inferenceService = new InferenceService(getBean(Vertx.class), Files.createTempDirectory("models").toString());
+        inferenceService.start();
+
+        resources.putIfAbsent(
+            "ai-model-text-classification",
+            ResourceBuilder.build(
+                "ai-model-text-classification",
+                TextClassificationAiModelResource.class,
+                TextClassificationAiModelConfiguration.class
+            )
+        );
+    }
+
+    @AfterAll
+    @SneakyThrows
+    static void afterAll() {
+        inferenceService.stop();
+    }
+
     @BeforeEach
     void setUp() {
         metricsSubject = BehaviorSubject.create();
@@ -74,16 +109,9 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
         fakeReporter.setReportableHandler(reportable -> {
             if (reportable instanceof Metrics) {
                 metricsSubject.onNext((Metrics) reportable);
+                metricsSubject.onComplete();
             }
         });
-    }
-
-    @Override
-    public void configureResources(Map<String, ResourcePlugin> resources) {
-        resources.putIfAbsent(
-            "fake-ai-model-text-classification",
-            ResourceBuilder.build("fake-ai-model-text-classification", FakeAiModelResource.class, FakeAiModelResourceConfiguration.class)
-        );
     }
 
     @Test
@@ -91,10 +119,9 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
     void should_flag_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
         wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-        metricsSubject
+        var metricsAsserts = metricsSubject
             .doOnNext(metrics ->
-                AssertionsForClassTypes
-                    .assertThat(metrics)
+                assertThat(metrics)
                     .extracting(Metrics::getAdditionalMetrics)
                     .asInstanceOf(InstanceOfAssertFactories.SET)
                     .containsExactlyInAnyOrder(
@@ -102,24 +129,28 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
                         new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
                     )
             )
-            .doOnNext(m -> context.completeNow())
-            .doOnError(context::failNow)
-            .subscribe();
+            .ignoreElements();
 
-        client
-            .rxRequest(HttpMethod.GET, "/log-request")
-            .flatMap(request ->
-                request.rxSend(
-                    """
-            {
-              "model": "GPT-2000",
-              "date": "01-01-2025",
-              "prompt": "Nobody asked for your toxic response."
-            }"""
-                )
+        var clientAsserts = Completable
+            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+            .andThen(
+                client
+                    .rxRequest(HttpMethod.GET, "/log-request")
+                    .flatMap(request ->
+                        request.rxSend(
+                            """
+                                                        {
+                                                          "model": "GPT-2000",
+                                                          "date": "01-01-2025",
+                                                          "prompt": "Nobody asked for your bullsh*t response."
+                                                        }"""
+                        )
+                    )
             )
-            .doOnSuccess(response -> AssertionsForClassTypes.assertThat(response.statusCode()).isEqualTo(200))
-            .subscribe();
+            .map(response -> assertThat(response.statusCode()).isEqualTo(200))
+            .ignoreElement();
+
+        finalAssert(context, metricsAsserts, clientAsserts);
     }
 
     @Test
@@ -127,63 +158,75 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
     void should_ignore_flagging_request_if_prompt_violation_not_detected(HttpClient client, VertxTestContext context) {
         wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-        metricsSubject
+        var metricsAsserts = metricsSubject
             .doOnNext(metrics ->
-                AssertionsForClassTypes
-                    .assertThat(metrics)
-                    .extracting(Metrics::getAdditionalMetrics)
-                    .asInstanceOf(InstanceOfAssertFactories.SET)
-                    .isEmpty()
+                assertThat(metrics).extracting(Metrics::getAdditionalMetrics).asInstanceOf(InstanceOfAssertFactories.SET).isEmpty()
             )
-            .doOnNext(m -> context.completeNow())
-            .doOnError(context::failNow)
-            .subscribe();
+            .ignoreElements();
 
-        client
-            .rxRequest(HttpMethod.GET, "/log-request")
-            .flatMap(request ->
-                request.rxSend(
-                    """
-                        {
-                          "model": "GPT-2000",
-                          "date": "01-01-2025",
-                          "prompt": "This is super friendly message"
-                        }"""
-                )
+        var clientAsserts = Completable
+            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+            .andThen(
+                client
+                    .rxRequest(HttpMethod.GET, "/log-request")
+                    .flatMap(request ->
+                        request.rxSend(
+                            """
+                                                        {
+                                                          "model": "GPT-2000",
+                                                          "date": "01-01-2025",
+                                                          "prompt": "This is super friendly message"
+                                                        }"""
+                        )
+                    )
             )
-            .doOnSuccess(response -> AssertionsForClassTypes.assertThat(response.statusCode()).isEqualTo(200))
-            .subscribe();
+            .map(response -> assertThat(response.statusCode()).isEqualTo(200))
+            .ignoreElement();
+
+        finalAssert(context, metricsAsserts, clientAsserts);
     }
 
     @Test
     @DeployApi({ "/apis/block_request_policy.json" })
-    void should_block_request_if_prompt_violation_detected(HttpClient client) {
+    void should_block_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
         wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-        client
-            .rxRequest(HttpMethod.GET, "/block-request")
-            .flatMap(request ->
-                request.rxSend(
-                    """
-                        {
-                          "model": "GPT-2000",
-                          "date": "01-01-2025",
-                          "prompt": "Nobody asked for your toxic response."
-                        }"""
-                )
+        var metricsAsserts = metricsSubject
+            .doOnNext(metrics ->
+                assertThat(metrics)
+                    .extracting(Metrics::getAdditionalMetrics)
+                    .asInstanceOf(InstanceOfAssertFactories.SET)
+                    .containsExactlyInAnyOrder(
+                        new AdditionalMetric.KeywordMetric("keyword_action", "request-blocked"),
+                        new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
+                    )
             )
-            .flatMapPublisher(response -> {
-                assertThat(response.statusCode()).isEqualTo(400);
-                return response.toFlowable();
-            })
-            .test()
-            .awaitDone(15, SECONDS)
-            .assertComplete()
-            .assertValue(responseBody -> {
-                assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic]");
-                return true;
-            })
-            .assertNoErrors();
+            .ignoreElements();
+
+        var clientAsserts = Completable
+            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+            .andThen(
+                client
+                    .rxRequest(HttpMethod.GET, "/block-request")
+                    .flatMap(request ->
+                        request.rxSend(
+                            """
+                                                        {
+                                                          "model": "GPT-2000",
+                                                          "date": "01-01-2025",
+                                                          "prompt": "Nobody asked for your bullsh*t response."
+                                                        }"""
+                        )
+                    )
+                    .flatMapPublisher(response -> {
+                        assertThat(response.statusCode()).isEqualTo(400);
+                        return response.toFlowable();
+                    })
+            )
+            .map(responseBody -> assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic]"))
+            .ignoreElements();
+
+        finalAssert(context, metricsAsserts, clientAsserts);
     }
 
     @Test
@@ -191,10 +234,9 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
     void should_change_sensitivity_if_custom_sensitivity_threshold_provided(HttpClient client, VertxTestContext context) {
         wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-        metricsSubject
+        var metricsAsserts = metricsSubject
             .doOnNext(metrics ->
-                AssertionsForClassTypes
-                    .assertThat(metrics)
+                assertThat(metrics)
                     .extracting(Metrics::getAdditionalMetrics)
                     .asInstanceOf(InstanceOfAssertFactories.SET)
                     .containsExactlyInAnyOrder(
@@ -202,59 +244,61 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
                         new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic,obscene")
                     )
             )
-            .doOnNext(m -> context.completeNow())
-            .doOnError(context::failNow)
-            .subscribe();
+            .ignoreElements();
 
-        client
-            .rxRequest(HttpMethod.GET, "/block-request")
-            .flatMap(request ->
-                request.rxSend(
-                    """
-                        {
-                          "model": "GPT-2000",
-                          "date": "01-01-2025",
-                          "prompt": "Nobody asked for your toxic and obscene response."
-                        }"""
-                )
+        var clientAsserts = Completable
+            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+            .andThen(
+                client
+                    .rxRequest(HttpMethod.GET, "/block-request")
+                    .flatMap(request ->
+                        request.rxSend(
+                            """
+                                                        {
+                                                          "model": "GPT-2000",
+                                                          "date": "01-01-2025",
+                                                          "prompt": "Nobody asked for your bullsh*t response."
+                                                        }"""
+                        )
+                    )
+                    .flatMapPublisher(response -> {
+                        assertThat(response.statusCode()).isEqualTo(400);
+                        return response.toFlowable();
+                    })
             )
-            .flatMapPublisher(response -> {
-                assertThat(response.statusCode()).isEqualTo(400);
-                return response.toFlowable();
-            })
-            .test()
-            .awaitDone(15, SECONDS)
-            .assertComplete()
-            .assertValue(responseBody -> {
-                assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic, obscene]");
-                return true;
-            })
-            .assertNoErrors();
+            .map(responseBody -> assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic, obscene]"))
+            .ignoreElements();
+
+        finalAssert(context, metricsAsserts, clientAsserts);
     }
 
     @Test
     @DeployApi({ "/apis/missing_resource.json" })
-    void should_return_error_if_resource_is_not_configured_properly(HttpClient client) {
+    void should_return_error_if_resource_is_not_configured_properly(HttpClient client) throws InterruptedException {
         wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-        client
-            .rxRequest(HttpMethod.GET, "/missing-resource")
-            .flatMap(request ->
-                request.rxSend(
-                    """
-                        {
-                          "model": "GPT-2000",
-                          "date": "01-01-2025",
-                          "prompt": "Nobody asked for your bullsh*t response."
-                        }"""
-                )
+        Completable
+            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+            .andThen(
+                client
+                    .rxRequest(HttpMethod.GET, "/missing-resource")
+                    .flatMap(request ->
+                        request.rxSend(
+                            """
+                                                        {
+                                                          "model": "GPT-2000",
+                                                          "date": "01-01-2025",
+                                                          "prompt": "Nobody asked for your bullsh*t response."
+                                                        }"""
+                        )
+                    )
+                    .flatMapPublisher(response -> {
+                        assertThat(response.statusCode()).isEqualTo(500);
+                        return response.toFlowable();
+                    })
             )
-            .flatMapPublisher(response -> {
-                assertThat(response.statusCode()).isEqualTo(500);
-                return response.toFlowable();
-            })
             .test()
-            .awaitDone(15, SECONDS)
+            .awaitDone(20, SECONDS)
             .assertComplete()
             .assertValue(responseBody -> {
                 assertThat(responseBody).hasToString("AI Model Text Classification resource incorrectly configured");
@@ -265,28 +309,48 @@ class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuard
 
     @Test
     @DeployApi({ "/apis/broken_content_check_list.json" })
-    void should_handle_parsing_incorrectly_formatted_list(HttpClient client) {
+    void should_handle_parsing_incorrectly_formatted_list(HttpClient client) throws InterruptedException {
         wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-        client
-            .rxRequest(HttpMethod.GET, "/broken-content-check")
-            .flatMap(request ->
-                request.rxSend(
-                    """
-                        {
-                          "model": "GPT-2000",
-                          "date": "01-01-2025",
-                          "prompt": "This is some friendly prompt"
-                        }"""
-                )
+        Completable
+            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+            .andThen(
+                client
+                    .rxRequest(HttpMethod.GET, "/broken-content-check")
+                    .flatMap(request ->
+                        request.rxSend(
+                            """
+                                                        {
+                                                          "model": "GPT-2000",
+                                                          "date": "01-01-2025",
+                                                          "prompt": "This is some friendly prompt"
+                                                        }"""
+                        )
+                    )
             )
             .test()
-            .awaitDone(15, SECONDS)
+            .awaitDone(20, SECONDS)
             .assertComplete()
             .assertValue(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
                 return true;
             })
             .assertNoErrors();
+    }
+
+    private static void finalAssert(VertxTestContext context, Completable metricsAsserts, Completable clientAsserts) {
+        Completable
+            .mergeArray(metricsAsserts, clientAsserts)
+            .doOnComplete(context::completeNow)
+            .doFinally(context::completeNow)
+            .doOnTerminate(context::completeNow)
+            .doOnEvent(e -> {
+                if (e == null) {
+                    context.completeNow();
+                } else {
+                    context.failNow(e);
+                }
+            })
+            .subscribe();
     }
 }

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicyIntegrationTest.java
@@ -23,16 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
-import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
-import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
 import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
 import io.gravitee.definition.model.ExecutionMode;
-import io.gravitee.inference.service.InferenceService;
-import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
-import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
-import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
-import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
 import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.policy.ai.prompt.guard.rails.configuration.AiPromptGuardRailsConfiguration;
 import io.gravitee.reporter.api.v4.metric.AdditionalMetric;
@@ -41,17 +33,16 @@ import io.gravitee.resource.ai_model.TextClassificationAiModelResource;
 import io.gravitee.resource.ai_model.configuration.TextClassificationAiModelConfiguration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
-import java.nio.file.Files;
 import java.util.Map;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 @Slf4j
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -59,277 +50,350 @@ import org.junit.jupiter.api.*;
 class AiPromptGuardRailsPolicyIntegrationTest extends AbstractPolicyTest<AiPromptGuardRailsPolicy, AiPromptGuardRailsConfiguration> {
 
     private static final Integer DELAY_BEFORE_REQUEST = 5;
-    BehaviorSubject<Metrics> metricsSubject;
 
-    private static InferenceService inferenceService;
+    @Nested
+    class WithFakeAiResource extends AbstractAiPromptGuardRailsPolicyIntegrationTest {
 
-    @Override
-    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
-        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
-    }
+        @Override
+        public void configureResources(Map<String, ResourcePlugin> resources) {
+            super.configureResources(resources);
 
-    @Override
-    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
-        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
-    }
-
-    @Override
-    @SneakyThrows
-    public void configureResources(Map<String, ResourcePlugin> resources) {
-        inferenceService = new InferenceService(getBean(Vertx.class), Files.createTempDirectory("models").toString());
-        inferenceService.start();
-
-        resources.putIfAbsent(
-            "ai-model-text-classification",
-            ResourceBuilder.build(
+            resources.putIfAbsent(
                 "ai-model-text-classification",
-                TextClassificationAiModelResource.class,
-                TextClassificationAiModelConfiguration.class
-            )
-        );
-    }
+                ResourceBuilder.build("ai-model-text-classification", FakeAiModelResource.class, FakeAiModelResourceConfiguration.class)
+            );
+        }
 
-    @AfterAll
-    @SneakyThrows
-    static void afterAll() {
-        inferenceService.stop();
-    }
+        @Test
+        @DeployApi({ "/apis/log_request_policy.json" })
+        void should_flag_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-    @BeforeEach
-    void setUp() {
-        metricsSubject = BehaviorSubject.create();
-
-        FakeReporter fakeReporter = getBean(FakeReporter.class);
-        fakeReporter.setReportableHandler(reportable -> {
-            if (reportable instanceof Metrics) {
-                metricsSubject.onNext((Metrics) reportable);
-                metricsSubject.onComplete();
-            }
-        });
-    }
-
-    @Test
-    @DeployApi({ "/apis/log_request_policy.json" })
-    void should_flag_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
-        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
-
-        var metricsAsserts = metricsSubject
-            .doOnNext(metrics ->
-                assertThat(metrics)
-                    .extracting(Metrics::getAdditionalMetrics)
-                    .asInstanceOf(InstanceOfAssertFactories.SET)
-                    .containsExactlyInAnyOrder(
-                        new AdditionalMetric.KeywordMetric("keyword_action", "request-logged"),
-                        new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
-                    )
-            )
-            .ignoreElements();
-
-        var clientAsserts = Completable
-            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
-            .andThen(
-                client
-                    .rxRequest(HttpMethod.GET, "/log-request")
-                    .flatMap(request ->
-                        request.rxSend(
-                            """
-                                                        {
-                                                          "model": "GPT-2000",
-                                                          "date": "01-01-2025",
-                                                          "prompt": "Nobody asked for your bullsh*t response."
-                                                        }"""
+            var metricsAsserts = metricsSubject
+                .doOnNext(metrics ->
+                    assertThat(metrics)
+                        .extracting(Metrics::getAdditionalMetrics)
+                        .asInstanceOf(InstanceOfAssertFactories.SET)
+                        .containsExactlyInAnyOrder(
+                            new AdditionalMetric.KeywordMetric("keyword_action", "request-logged"),
+                            new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
                         )
-                    )
-            )
-            .map(response -> assertThat(response.statusCode()).isEqualTo(200))
-            .ignoreElement();
+                )
+                .ignoreElements();
 
-        finalAssert(context, metricsAsserts, clientAsserts);
+            var clientAsserts = client
+                .rxRequest(HttpMethod.GET, "/log-request")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                                            {
+                                              "model": "GPT-2000",
+                                              "date": "01-01-2025",
+                                              "prompt": "Nobody asked for your bullsh*t response."
+                                            }"""
+                    )
+                )
+                .map(response -> assertThat(response.statusCode()).isEqualTo(200))
+                .ignoreElement();
+
+            finalAssert(context, metricsAsserts, clientAsserts);
+        }
+
+        @Test
+        @DeployApi({ "/apis/log_request_policy.json" })
+        void should_ignore_flagging_request_if_prompt_violation_not_detected(HttpClient client, VertxTestContext context) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            var metricsAsserts = metricsSubject
+                .doOnNext(metrics ->
+                    assertThat(metrics).extracting(Metrics::getAdditionalMetrics).asInstanceOf(InstanceOfAssertFactories.SET).isEmpty()
+                )
+                .ignoreElements();
+
+            var clientAsserts = client
+                .rxRequest(HttpMethod.GET, "/log-request")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                                                    {
+                                                      "model": "GPT-2000",
+                                                      "date": "01-01-2025",
+                                                      "prompt": "This is super friendly message"
+                                                    }"""
+                    )
+                )
+                .map(response -> assertThat(response.statusCode()).isEqualTo(200))
+                .ignoreElement();
+
+            finalAssert(context, metricsAsserts, clientAsserts);
+        }
+
+        @Test
+        @DeployApi({ "/apis/block_request_policy.json" })
+        void should_block_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            var metricsAsserts = metricsSubject
+                .doOnNext(metrics ->
+                    assertThat(metrics)
+                        .extracting(Metrics::getAdditionalMetrics)
+                        .asInstanceOf(InstanceOfAssertFactories.SET)
+                        .containsExactlyInAnyOrder(
+                            new AdditionalMetric.KeywordMetric("keyword_action", "request-blocked"),
+                            new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
+                        )
+                )
+                .ignoreElements();
+
+            var clientAsserts = client
+                .rxRequest(HttpMethod.GET, "/block-request")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                                                    {
+                                                      "model": "GPT-2000",
+                                                      "date": "01-01-2025",
+                                                      "prompt": "Nobody asked for your bullsh*t response."
+                                                    }"""
+                    )
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(400);
+                    return response.toFlowable();
+                })
+                .map(responseBody -> assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic]"))
+                .ignoreElements();
+
+            finalAssert(context, metricsAsserts, clientAsserts);
+        }
+
+        @Test
+        @DeployApi({ "/apis/custom_sensitivity_threshold.json" })
+        void should_change_sensitivity_if_custom_sensitivity_threshold_provided(HttpClient client, VertxTestContext context) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            var metricsAsserts = metricsSubject
+                .doOnNext(metrics ->
+                    assertThat(metrics)
+                        .extracting(Metrics::getAdditionalMetrics)
+                        .asInstanceOf(InstanceOfAssertFactories.SET)
+                        .containsExactlyInAnyOrder(
+                            new AdditionalMetric.KeywordMetric("keyword_action", "request-blocked"),
+                            new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic,obscene")
+                        )
+                )
+                .ignoreElements();
+
+            var clientAsserts = client
+                .rxRequest(HttpMethod.GET, "/block-request")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                                                    {
+                                                      "model": "GPT-2000",
+                                                      "date": "01-01-2025",
+                                                      "prompt": "Nobody asked for your bullsh*t response."
+                                                    }"""
+                    )
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(400);
+                    return response.toFlowable();
+                })
+                .map(responseBody -> assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic, obscene]"))
+                .ignoreElements();
+
+            finalAssert(context, metricsAsserts, clientAsserts);
+        }
+
+        @Test
+        @DeployApi({ "/apis/missing_resource.json" })
+        void should_return_error_if_resource_is_not_configured_properly(HttpClient client) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            client
+                .rxRequest(HttpMethod.GET, "/missing-resource")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                                            {
+                                              "model": "GPT-2000",
+                                              "date": "01-01-2025",
+                                              "prompt": "Nobody asked for your bullsh*t response."
+                                            }"""
+                    )
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(500);
+                    return response.toFlowable();
+                })
+                .test()
+                .awaitDone(20, SECONDS)
+                .assertComplete()
+                .assertValue(responseBody -> {
+                    assertThat(responseBody).hasToString("AI Model Text Classification resource incorrectly configured");
+                    return true;
+                })
+                .assertNoErrors();
+        }
+
+        @Test
+        @DeployApi({ "/apis/broken_content_check_list.json" })
+        void should_handle_parsing_incorrectly_formatted_list(HttpClient client) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            client
+                .rxRequest(HttpMethod.GET, "/broken-content-check")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                                            {
+                                              "model": "GPT-2000",
+                                              "date": "01-01-2025",
+                                              "prompt": "This is some friendly prompt"
+                                            }"""
+                    )
+                )
+                .test()
+                .awaitDone(20, SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return true;
+                })
+                .assertNoErrors();
+        }
+
+        @Test
+        @DeployApi({ "/apis/log_request_policy.json" })
+        void should_return_an_error_when_inference_fail(HttpClient client) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            client
+                .rxRequest(HttpMethod.GET, "/log-request")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                                            {
+                                              "model": "GPT-2000",
+                                              "date": "01-01-2025",
+                                              "prompt": "not ready. Nobody asked for your bullsh*t response."
+                                            }"""
+                    )
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(503);
+                    return response.toFlowable();
+                })
+                .test()
+                .awaitDone(20, SECONDS)
+                .assertComplete()
+                .assertValue(responseBody -> {
+                    assertThat(responseBody).hasToString("Model is not ready");
+                    return true;
+                })
+                .assertNoErrors();
+        }
     }
 
-    @Test
-    @DeployApi({ "/apis/log_request_policy.json" })
-    void should_ignore_flagging_request_if_prompt_violation_not_detected(HttpClient client, VertxTestContext context) {
-        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+    @Nested
+    class WithRealAiResource extends AbstractAiPromptGuardRailsPolicyIntegrationTest {
 
-        var metricsAsserts = metricsSubject
-            .doOnNext(metrics ->
-                assertThat(metrics).extracting(Metrics::getAdditionalMetrics).asInstanceOf(InstanceOfAssertFactories.SET).isEmpty()
-            )
-            .ignoreElements();
+        @Override
+        public void configureResources(Map<String, ResourcePlugin> resources) {
+            super.configureResources(resources);
 
-        var clientAsserts = Completable
-            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
-            .andThen(
-                client
-                    .rxRequest(HttpMethod.GET, "/log-request")
-                    .flatMap(request ->
-                        request.rxSend(
-                            """
-                                                        {
-                                                          "model": "GPT-2000",
-                                                          "date": "01-01-2025",
-                                                          "prompt": "This is super friendly message"
-                                                        }"""
+            resources.putIfAbsent(
+                "ai-model-text-classification",
+                ResourceBuilder.build(
+                    "ai-model-text-classification",
+                    TextClassificationAiModelResource.class,
+                    TextClassificationAiModelConfiguration.class
+                )
+            );
+        }
+
+        @Test
+        @DeployApi({ "/apis/log_request_policy.json" })
+        void should_flag_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            var metricsAsserts = metricsSubject
+                .doOnNext(metrics ->
+                    assertThat(metrics)
+                        .extracting(Metrics::getAdditionalMetrics)
+                        .asInstanceOf(InstanceOfAssertFactories.SET)
+                        .containsExactlyInAnyOrder(
+                            new AdditionalMetric.KeywordMetric("keyword_action", "request-logged"),
+                            new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
                         )
-                    )
-            )
-            .map(response -> assertThat(response.statusCode()).isEqualTo(200))
-            .ignoreElement();
+                )
+                .ignoreElements();
 
-        finalAssert(context, metricsAsserts, clientAsserts);
-    }
-
-    @Test
-    @DeployApi({ "/apis/block_request_policy.json" })
-    void should_block_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
-        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
-
-        var metricsAsserts = metricsSubject
-            .doOnNext(metrics ->
-                assertThat(metrics)
-                    .extracting(Metrics::getAdditionalMetrics)
-                    .asInstanceOf(InstanceOfAssertFactories.SET)
-                    .containsExactlyInAnyOrder(
-                        new AdditionalMetric.KeywordMetric("keyword_action", "request-blocked"),
-                        new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
-                    )
-            )
-            .ignoreElements();
-
-        var clientAsserts = Completable
-            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
-            .andThen(
-                client
-                    .rxRequest(HttpMethod.GET, "/block-request")
-                    .flatMap(request ->
-                        request.rxSend(
-                            """
-                                                        {
-                                                          "model": "GPT-2000",
-                                                          "date": "01-01-2025",
-                                                          "prompt": "Nobody asked for your bullsh*t response."
-                                                        }"""
+            var clientAsserts = Completable
+                .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+                .andThen(
+                    client
+                        .rxRequest(HttpMethod.GET, "/log-request")
+                        .flatMap(request ->
+                            request.rxSend(
+                                """
+                                                            {
+                                                              "model": "GPT-2000",
+                                                              "date": "01-01-2025",
+                                                              "prompt": "Nobody asked for your bullsh*t response."
+                                                            }"""
+                            )
                         )
-                    )
-                    .flatMapPublisher(response -> {
-                        assertThat(response.statusCode()).isEqualTo(400);
-                        return response.toFlowable();
-                    })
-            )
-            .map(responseBody -> assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic]"))
-            .ignoreElements();
+                )
+                .map(response -> assertThat(response.statusCode()).isEqualTo(200))
+                .ignoreElement();
 
-        finalAssert(context, metricsAsserts, clientAsserts);
-    }
+            finalAssert(context, metricsAsserts, clientAsserts);
+        }
 
-    @Test
-    @DeployApi({ "/apis/custom_sensitivity_threshold.json" })
-    void should_change_sensitivity_if_custom_sensitivity_threshold_provided(HttpClient client, VertxTestContext context) {
-        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+        @Test
+        @DeployApi({ "/apis/block_request_policy.json" })
+        void should_block_request_if_prompt_violation_detected(HttpClient client, VertxTestContext context) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
 
-        var metricsAsserts = metricsSubject
-            .doOnNext(metrics ->
-                assertThat(metrics)
-                    .extracting(Metrics::getAdditionalMetrics)
-                    .asInstanceOf(InstanceOfAssertFactories.SET)
-                    .containsExactlyInAnyOrder(
-                        new AdditionalMetric.KeywordMetric("keyword_action", "request-blocked"),
-                        new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic,obscene")
-                    )
-            )
-            .ignoreElements();
-
-        var clientAsserts = Completable
-            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
-            .andThen(
-                client
-                    .rxRequest(HttpMethod.GET, "/block-request")
-                    .flatMap(request ->
-                        request.rxSend(
-                            """
-                                                        {
-                                                          "model": "GPT-2000",
-                                                          "date": "01-01-2025",
-                                                          "prompt": "Nobody asked for your bullsh*t response."
-                                                        }"""
+            var metricsAsserts = metricsSubject
+                .doOnNext(metrics ->
+                    assertThat(metrics)
+                        .extracting(Metrics::getAdditionalMetrics)
+                        .asInstanceOf(InstanceOfAssertFactories.SET)
+                        .containsExactlyInAnyOrder(
+                            new AdditionalMetric.KeywordMetric("keyword_action", "request-blocked"),
+                            new AdditionalMetric.KeywordMetric("keyword_content_violations", "toxic")
                         )
-                    )
-                    .flatMapPublisher(response -> {
-                        assertThat(response.statusCode()).isEqualTo(400);
-                        return response.toFlowable();
-                    })
-            )
-            .map(responseBody -> assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic, obscene]"))
-            .ignoreElements();
+                )
+                .ignoreElements();
 
-        finalAssert(context, metricsAsserts, clientAsserts);
-    }
-
-    @Test
-    @DeployApi({ "/apis/missing_resource.json" })
-    void should_return_error_if_resource_is_not_configured_properly(HttpClient client) throws InterruptedException {
-        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
-
-        Completable
-            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
-            .andThen(
-                client
-                    .rxRequest(HttpMethod.GET, "/missing-resource")
-                    .flatMap(request ->
-                        request.rxSend(
-                            """
-                                                        {
-                                                          "model": "GPT-2000",
-                                                          "date": "01-01-2025",
-                                                          "prompt": "Nobody asked for your bullsh*t response."
-                                                        }"""
+            var clientAsserts = Completable
+                .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
+                .andThen(
+                    client
+                        .rxRequest(HttpMethod.GET, "/block-request")
+                        .flatMap(request ->
+                            request.rxSend(
+                                """
+                                                            {
+                                                              "model": "GPT-2000",
+                                                              "date": "01-01-2025",
+                                                              "prompt": "Nobody asked for your bullsh*t response."
+                                                            }"""
+                            )
                         )
-                    )
-                    .flatMapPublisher(response -> {
-                        assertThat(response.statusCode()).isEqualTo(500);
-                        return response.toFlowable();
-                    })
-            )
-            .test()
-            .awaitDone(20, SECONDS)
-            .assertComplete()
-            .assertValue(responseBody -> {
-                assertThat(responseBody).hasToString("AI Model Text Classification resource incorrectly configured");
-                return true;
-            })
-            .assertNoErrors();
-    }
+                        .flatMapPublisher(response -> {
+                            assertThat(response.statusCode()).isEqualTo(400);
+                            return response.toFlowable();
+                        })
+                )
+                .map(responseBody -> assertThat(responseBody).hasToString("AI prompt validation detected. Reason: [toxic]"))
+                .ignoreElements();
 
-    @Test
-    @DeployApi({ "/apis/broken_content_check_list.json" })
-    void should_handle_parsing_incorrectly_formatted_list(HttpClient client) throws InterruptedException {
-        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
-
-        Completable
-            .fromObservable(Observable.timer(DELAY_BEFORE_REQUEST, SECONDS))
-            .andThen(
-                client
-                    .rxRequest(HttpMethod.GET, "/broken-content-check")
-                    .flatMap(request ->
-                        request.rxSend(
-                            """
-                                                        {
-                                                          "model": "GPT-2000",
-                                                          "date": "01-01-2025",
-                                                          "prompt": "This is some friendly prompt"
-                                                        }"""
-                        )
-                    )
-            )
-            .test()
-            .awaitDone(20, SECONDS)
-            .assertComplete()
-            .assertValue(response -> {
-                assertThat(response.statusCode()).isEqualTo(200);
-                return true;
-            })
-            .assertNoErrors();
+            finalAssert(context, metricsAsserts, clientAsserts);
+        }
     }
 
     private static void finalAssert(VertxTestContext context, Completable metricsAsserts, Completable clientAsserts) {

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicyIntegrationTest.java
@@ -19,7 +19,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
 
 import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
@@ -39,9 +38,6 @@ import io.gravitee.policy.ai.prompt.guard.rails.configuration.AiPromptGuardRails
 import io.gravitee.reporter.api.v4.metric.AdditionalMetric;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.gravitee.resource.ai_model.TextClassificationAiModelResource;
-import io.gravitee.resource.ai_model.client.TextClassificationInferenceClient;
-import io.gravitee.resource.ai_model.configuration.ModelConfiguration;
-import io.gravitee.resource.ai_model.configuration.ModelEnum;
 import io.gravitee.resource.ai_model.configuration.TextClassificationAiModelConfiguration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
@@ -56,13 +52,11 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @Slf4j
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @GatewayTest(v2ExecutionMode = ExecutionMode.V4_EMULATION_ENGINE)
-class AiPromptGuardRailsIntegrationTest extends AbstractPolicyTest<AiPromptGuardRailsPolicy, AiPromptGuardRailsConfiguration> {
+class AiPromptGuardRailsPolicyIntegrationTest extends AbstractPolicyTest<AiPromptGuardRailsPolicy, AiPromptGuardRailsConfiguration> {
 
     private static final Integer DELAY_BEFORE_REQUEST = 5;
     BehaviorSubject<Metrics> metricsSubject;

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/FakeAiModelResource.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/FakeAiModelResource.java
@@ -20,6 +20,8 @@ import io.gravitee.resource.ai_model.api.InferenceServiceClient;
 import io.gravitee.resource.ai_model.api.model.PromptInput;
 import io.gravitee.resource.ai_model.api.result.ClassifierResults;
 import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
 import java.util.ArrayList;
 
 public class FakeAiModelResource
@@ -33,8 +35,11 @@ public class FakeAiModelResource
 
     @Override
     public Single<ClassifierResults> invokeModel(PromptInput promptInput) {
-        var result = new ArrayList<ClassifierResults.ClassifierResult>();
+        if (promptInput.promptContent().contains("not ready")) {
+            return Single.error(new ReplyException(ReplyFailure.ERROR, 503, "Model is not ready"));
+        }
 
+        var result = new ArrayList<ClassifierResults.ClassifierResult>();
         if (promptInput.promptContent().contains("toxic") || promptInput.promptContent().contains("bullsh*t")) {
             result.add(new ClassifierResults.ClassifierResult("toxic", 0.9F, "token", 0, 1));
         }

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/FakeAiModelResource.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/FakeAiModelResource.java
@@ -15,28 +15,46 @@
  */
 package io.gravitee.policy.ai.prompt.guard.rails;
 
-import io.gravitee.resource.ai_model.api.AiTextClassificationModelResource;
-import io.gravitee.resource.ai_model.api.ClassifierResults;
+import io.gravitee.resource.ai_model.api.AiTextModelResource;
+import io.gravitee.resource.ai_model.api.InferenceServiceClient;
 import io.gravitee.resource.ai_model.api.model.PromptInput;
+import io.gravitee.resource.ai_model.api.result.ClassifierResults;
 import io.reactivex.rxjava3.core.Single;
 import java.util.ArrayList;
 
-public class FakeAiModelResource extends AiTextClassificationModelResource<FakeAiModelResourceConfiguration> {
+public class FakeAiModelResource
+    extends AiTextModelResource<FakeAiModelResourceConfiguration, io.gravitee.inference.api.classifier.ClassifierResults, io.gravitee.resource.ai_model.api.result.ClassifierResults> {
+
+    @Override
+    public void doStart() {}
+
+    @Override
+    public void doStop() {}
 
     @Override
     public Single<ClassifierResults> invokeModel(PromptInput promptInput) {
         var result = new ArrayList<ClassifierResults.ClassifierResult>();
 
-        if (promptInput.promptContent().contains("toxic")) {
+        if (promptInput.promptContent().contains("toxic") || promptInput.promptContent().contains("bullsh*t")) {
             result.add(new ClassifierResults.ClassifierResult("toxic", 0.9F, "token", 0, 1));
         }
         if (promptInput.promptContent().contains("identity_hate")) {
             result.add(new ClassifierResults.ClassifierResult("identity_hate", 0.8F, "token", 0, 1));
         }
-        if (promptInput.promptContent().contains("obscene")) {
+        if (promptInput.promptContent().contains("obscene") || promptInput.promptContent().contains("bullsh*t")) {
             result.add(new ClassifierResults.ClassifierResult("obscene", 0.2F, "token", 0, 1));
         }
 
         return Single.just(new ClassifierResults(result));
+    }
+
+    @Override
+    protected String getModelName() {
+        return "";
+    }
+
+    @Override
+    protected InferenceServiceClient<PromptInput, io.gravitee.inference.api.classifier.ClassifierResults> buildInferenceServiceClient() {
+        return null;
     }
 }

--- a/src/test/resources/apis/block_request_policy.json
+++ b/src/test/resources/apis/block_request_policy.json
@@ -40,8 +40,12 @@
     "resources": [
         {
             "name": "ai-model-text-classification-resource",
-            "type": "fake-ai-model-text-classification",
-            "configuration": {},
+            "type": "ai-model-text-classification",
+            "configuration": {
+                "model": {
+                    "type": "MINILMV2_TOXIC_JIGSAW_MODEL"
+                }
+            },
             "enabled": true
         }
     ],

--- a/src/test/resources/apis/broken_content_check_list.json
+++ b/src/test/resources/apis/broken_content_check_list.json
@@ -40,8 +40,12 @@
     "resources": [
         {
             "name": "ai-model-text-classification-resource",
-            "type": "fake-ai-model-text-classification",
-            "configuration": {},
+            "type": "ai-model-text-classification",
+            "configuration": {
+                "model": {
+                    "type": "MINILMV2_TOXIC_JIGSAW_MODEL"
+                }
+            },
             "enabled": true
         }
     ],

--- a/src/test/resources/apis/custom_sensitivity_threshold.json
+++ b/src/test/resources/apis/custom_sensitivity_threshold.json
@@ -40,8 +40,12 @@
     "resources": [
         {
             "name": "ai-model-text-classification-resource",
-            "type": "fake-ai-model-text-classification",
-            "configuration": {},
+            "type": "ai-model-text-classification",
+            "configuration": {
+                "model": {
+                    "type": "MINILMV2_TOXIC_JIGSAW_MODEL"
+                }
+            },
             "enabled": true
         }
     ],

--- a/src/test/resources/apis/log_request_policy.json
+++ b/src/test/resources/apis/log_request_policy.json
@@ -40,8 +40,12 @@
     "resources": [
         {
             "name": "ai-model-text-classification-resource",
-            "type": "fake-ai-model-text-classification",
-            "configuration": {},
+            "type": "ai-model-text-classification",
+            "configuration": {
+                "model": {
+                    "type": "MINILMV2_TOXIC_JIGSAW_MODEL"
+                }
+            },
             "enabled": true
         }
     ],

--- a/src/test/resources/apis/missing_resource.json
+++ b/src/test/resources/apis/missing_resource.json
@@ -40,7 +40,7 @@
     "resources": [
         {
             "name": "not-existing-resource",
-            "type": "fake-ai-model-text-classification",
+            "type": "ai-model-text-classification",
             "configuration": {},
             "enabled": true
         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-XXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bump-ai-model-resource-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ai-prompt-guard-rails/2.0.0-bump-ai-model-resource-api-SNAPSHOT/gravitee-policy-ai-prompt-guard-rails-2.0.0-bump-ai-model-resource-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
