### PR TITLE
fix: filter not applied to block reason, exposing labels in error response

### DIFF
--- a/src/main/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicy.java
+++ b/src/main/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicy.java
@@ -30,6 +30,7 @@ import io.vertx.core.eventbus.ReplyException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 
 @Slf4j
 @RequireResource
@@ -79,12 +80,10 @@ public class AiPromptGuardRailsPolicy implements HttpPolicy {
             aiModelResource
                 .invokeModel(new PromptInput(prompt))
                 .flatMapCompletable(classifierResults -> {
-                    var detectedContentTypes = detectClassifierResultContentTypes(classifierResults, sensitivityThreshold);
-                    if (
-                        !detectedContentTypes.isEmpty() &&
-                        (configuration.parseContentChecks().isEmpty() ||
-                            configuration.parseContentChecks().stream().anyMatch(detectedContentTypes::contains))
-                    ) {
+                    Set<String> allDetected = detectClassifierResultContentTypes(classifierResults, sensitivityThreshold);
+                    var detectedContentTypes = configuration.parseContentChecks().isEmpty() ? allDetected : filteredWithConfig(allDetected);
+
+                    if (!detectedContentTypes.isEmpty()) {
                         logMetrics(detectedContentTypes, ctx, configuration.requestPolicy().getAction());
                         if (RequestPolicy.BLOCK_REQUEST.equals(configuration.requestPolicy())) {
                             return Completable.error(new BlockQueryException(detectedContentTypes));
@@ -102,6 +101,10 @@ public class AiPromptGuardRailsPolicy implements HttpPolicy {
                     }
                 )
         );
+    }
+
+    private @NonNull Set<String> filteredWithConfig(Set<String> allDetected) {
+        return allDetected.stream().filter(configuration.parseContentChecks()::contains).collect(Collectors.toSet());
     }
 
     private void logMetrics(Set<String> detectedCategories, HttpPlainExecutionContext ctx, String action) {

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/AiPromptGuardRailsPolicyIntegrationTest.java
@@ -301,6 +301,49 @@ class AiPromptGuardRailsPolicyIntegrationTest extends AbstractPolicyTest<AiPromp
         }
 
         @Test
+        @DeployApi({ "/apis/block_request_policy_filtered_contentChecks.json" })
+        void should_only_report_configured_contentChecks_labels_when_multiple_labels_detected_above_threshold(
+            HttpClient client,
+            VertxTestContext context
+        ) {
+            wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));
+
+            // When: prompt triggers both "toxic" (0.9) and "obscene" (0.2), threshold is 0.1 so both pass,
+            // but contentChecks is restricted to "toxic" only
+            var clientAsserts = client
+                .rxRequest(HttpMethod.GET, "/block-request-filtered-contentChecks")
+                .flatMap(request ->
+                    request.rxSend(
+                        """
+                        {
+                          "model": "GPT-2000",
+                          "date": "01-01-2025",
+                          "prompt": "hello! I'm a toxic message."
+                        }
+                        """
+                    )
+                )
+                .flatMap(this::toResult);
+
+            // Then: response reason must only contain "toxic", not "obscene"
+            then(clientAsserts).subscribe(
+                result ->
+                    context
+                        .verify(() -> {
+                            assertThat(result.statusCode()).isEqualTo(400);
+                            assertThat(result.responseBody()).hasToString("AI prompt validation detected. Reason: [toxic]");
+                            assertThat(result.metrics())
+                                .extracting(Metrics::getAdditionalMetrics)
+                                .asInstanceOf(InstanceOfAssertFactories.SET)
+                                .areExactly(1, keyword("keyword_action", "request-blocked"))
+                                .areExactly(1, keyword("keyword_content_violations", "toxic"));
+                        })
+                        .completeNow(),
+                context::failNow
+            );
+        }
+
+        @Test
         @DeployApi({ "/apis/block_request_policy_empty_contentChecks.json" })
         void should_block_request_if_prompt_violation_detected_and_empty_contentChecks(HttpClient client, VertxTestContext context) {
             wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(200)));

--- a/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/FakeAiModelResource.java
+++ b/src/test/java/io/gravitee/policy/ai/prompt/guard/rails/FakeAiModelResource.java
@@ -53,6 +53,10 @@ public class FakeAiModelResource
         if (promptInput.promptContent().contains("obscene") || promptInput.promptContent().contains("bullsh*t")) {
             result.add(new ClassifierResults.ClassifierResult("obscene", 0.2F, "token", 0, 1));
         }
+        if (promptInput.promptContent().contains("hello!")) {
+            result.add(new ClassifierResults.ClassifierResult("toxic", 0.9F, "token", 0, 1));
+            result.add(new ClassifierResults.ClassifierResult("obscene", 0.15F, "token", 0, 1));
+        }
 
         return Single.just(new ClassifierResults(result));
     }

--- a/src/test/resources/apis/block_request_policy_filtered_contentChecks.json
+++ b/src/test/resources/apis/block_request_policy_filtered_contentChecks.json
@@ -1,0 +1,83 @@
+{
+    "id": "v4-ai-prompt-guard-rails-block-request-filtered-contentChecks",
+    "name": "v4-ai-prompt-guard-rails-block-request-filtered-contentChecks",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "analytics": {},
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/block-request-filtered-contentChecks"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "ai-model-text-classification-resource",
+            "type": "ai-model-text-classification",
+            "configuration": {
+                "model": {
+                    "type": "MINILMV2_TOXIC_JIGSAW_MODEL"
+                }
+            },
+            "enabled": true
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [
+                {
+                    "name": "AI Prompt Guard Rails",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "ai-prompt-guard-rails",
+                    "configuration": {
+                        "resourceName": "ai-model-text-classification-resource",
+                        "promptLocation": "{#request.jsonContent.prompt}",
+                        "sensitivityThreshold": "0.1",
+                        "contentChecks": "toxic",
+                        "requestPolicy": "BLOCK_REQUEST"
+                    }
+                }
+            ],
+            "response": [],
+            "subscribe": [],
+            "publish": []
+        }
+    ]
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13770

**Description**

When the classifier returns multiple labels above the sensitivity threshold, the policy was building the block reason from all detected labels instead of intersecting with the configured contentChecks. This caused labels not explicitly configured (e.g. not-toxic) to leak into the 400 error response.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.2-fix-wrongly-filtered-apis-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ai-prompt-guard-rails/3.2.2-fix-wrongly-filtered-apis-SNAPSHOT/gravitee-policy-ai-prompt-guard-rails-3.2.2-fix-wrongly-filtered-apis-SNAPSHOT.zip)
  <!-- Version placeholder end -->
