### PR TITLE
Clean pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,14 @@
 
     <properties>
         <!-- Gravitee dependencies version -->
-        <gravitee-apim.version>4.12.0-SNAPSHOT</gravitee-apim.version>
-        <gravitee-inference-service.version>2.0.0-alpha.2</gravitee-inference-service.version>
+        <gravitee-apim.version>4.12.0-milestone.4</gravitee-apim.version>
+        <gravitee-inference-service.version>2.0.0</gravitee-inference-service.version>
         <gravitee-resource-ai-model-api.version>2.2.3</gravitee-resource-ai-model-api.version>
 
         <!-- Tests -->
         <gravitee-resource-ai-model-text-classification.version>2.2.1</gravitee-resource-ai-model-text-classification.version>
 
         <!-- Maven plugins -->
-        <maven-plugin-assembly.version>3.8.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.3.0</maven-plugin-properties.version>
 
         <!-- Property used by the publication job in CI-->
@@ -206,7 +205,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>


### PR DESCRIPTION
**Issue**

N/A
**Description**

Remove snapshot and pre-release dependencies
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-remove-snapshot-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ai-prompt-guard-rails/4.0.1-remove-snapshot-dependencies-SNAPSHOT/gravitee-policy-ai-prompt-guard-rails-4.0.1-remove-snapshot-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
